### PR TITLE
商品情報編集機能の実装

### DIFF
--- a/app/controllers/item_purchases_controller.rb
+++ b/app/controllers/item_purchases_controller.rb
@@ -1,5 +1,9 @@
 class ItemPurchasesController < ApplicationController
 
+  def index
+    @items = Item.new
+  end
+
 
   def show
     @items = Item.new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -23,7 +23,11 @@ class ItemsController < ApplicationController
   end
 
   def update
-    @items.update(items_params)
+    if @items = Item.update(items_params)
+        redirect_to edit_item_path(@items)
+    else
+      render :edit
+    end
   end
 
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -19,8 +19,13 @@ class ItemsController < ApplicationController
   end
 
   def edit
-    @items = Item.new
+    @items = Item.find(params[:id])
   end
+
+  def update
+    @items.update(items_params)
+  end
+
 
   def show
     @items = Item.find(params[:id])

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,6 @@
 class ItemsController < ApplicationController
   before_action :move_to_index, except: [:index, :show, :edit, :new]
+  before_action :set_item, only: [:edit, :show]
 
   def index
     @items = Item.all.order(product_name: "DESC")
@@ -19,7 +20,6 @@ class ItemsController < ApplicationController
   end
 
   def edit
-    @items = Item.find(params[:id])
   end
 
   def update
@@ -28,7 +28,6 @@ class ItemsController < ApplicationController
 
 
   def show
-    @items = Item.find(params[:id])
   end
 
   def move_to_index
@@ -36,6 +35,11 @@ class ItemsController < ApplicationController
       redirect_to action: :index
     end
   end
+
+  def set_item
+    @items = Item.find(params[:id])
+  end
+
 
   private
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -24,7 +24,7 @@ class ItemsController < ApplicationController
 
   def update
     if @items = Item.update(items_params)
-        redirect_to edit_item_path(@items)
+        redirect_to item_path(items_params)
     else
       render :edit
     end

--- a/app/views/item_purchases/index.html.erb
+++ b/app/views/item_purchases/index.html.erb
@@ -1,0 +1,128 @@
+<%= render "shared/second-header"%>
+
+<div class='transaction-contents'>
+  <div class='transaction-main'>
+    <h1 class='transaction-title-text'>
+      購入内容の確認
+    </h1>
+    <%# 購入内容の表示 %>
+    <div class='buy-item-info'>
+      <%= image_tag "item-sample.png", class: 'buy-item-img' %>
+      <div class='buy-item-right-content'>
+        <h2 class='buy-item-text'>
+          <%= "商品説明" %>
+        </h2>
+        <div class='buy-item-price'>
+          <p class='item-price-text'>¥<%= 999,999,999 %></p>
+          <p class='item-price-sub-text'>（税込）送料込み</p>
+        </div>
+      </div>
+    </div>
+    <%# /購入内容の表示 %>
+
+    <%# 支払額の表示 %>
+    <div class='item-payment'>
+      <h1 class='item-payment-title'>
+        支払金額
+      </h1>
+      <p class='item-payment-price'>
+        ¥<%= "販売価格" %>
+      </p>
+    </div>
+    <%# /支払額の表示 %>
+
+    <%= form_with id: 'charge-form', class: 'transaction-form-wrap',local: true do |f| %>
+    <%# カード情報の入力 %>
+    <div class='credit-card-form'>
+      <h1 class='info-input-haedline'>
+        クレジットカード情報入力
+      </h1>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">カード情報</label>
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.text_field 'hoge', class:"input-default", id:"card-number", placeholder:"カード番号(半角英数字)", maxlength:"16" %>
+        <div class='available-card'>
+          <%= image_tag 'card-visa.gif', class: 'card-logo'%>
+          <%= image_tag 'card-mastercard.gif', class: 'card-logo'%>
+          <%= image_tag 'card-jcb.gif', class: 'card-logo'%>
+          <%= image_tag 'card-amex.gif', class: 'card-logo'%>
+        </div>
+      </div>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">有効期限</label>
+          <span class="indispensable">必須</span>
+        </div>
+        <div class='input-expiration-date-wrap'>
+          <%= f.text_area 'hoge', class:"input-expiration-date", id:"card-exp-month", placeholder:"例)3" %>
+          <p>月</p>
+          <%= f.text_area 'hoge', class:"input-expiration-date", id:"card-exp-year", placeholder:"例)23" %>
+          <p>年</p>
+        </div>
+      </div>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">セキュリティコード</label>
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.text_field "hoge",class:"input-default", id:"card-cvc", placeholder:"カード背面4桁もしくは3桁の番号", maxlength:"4" %>
+      </div>
+    </div>
+    <%# /カード情報の入力 %>
+    <%# 配送先の入力 %>
+    <div class='shipping-address-form'>
+      <h1 class='info-input-haedline'>
+        配送先入力
+      </h1>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">郵便番号</label>
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.text_field 'hoge', class:"input-default", id:"postal-code", placeholder:"例）123-4567", maxlength:"8" %>
+      </div>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">都道府県</label>
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"prefecture"}) %>
+      </div>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">市区町村</label>
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.text_field 'hoge', class:"input-default", id:"city", placeholder:"例）横浜市緑区"%>
+      </div>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">番地</label>
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.text_field 'hoge', class:"input-default", id:"addresses", placeholder:"例）青山1-1-1"%>
+      </div>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">建物名</label>
+          <span class="form-any">任意</span>
+        </div>
+        <%= f.text_field 'hoge', class:"input-default", id:"building", placeholder:"例）柳ビル103"%>
+      </div>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">電話番号</label>
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.text_field 'hoge', class:"input-default", id:"phone-number", placeholder:"例）09012345678",maxlength:"11"%>
+      </div>
+    </div>
+    <div class='buy-btn'>
+      <%= f.submit "購入" ,class:"buy-red-btn" %>
+    </div>
+    <% end %>
+  </div>
+</div>
+<%= render "shared/second-footer"%>

--- a/app/views/item_purchases/index.html.erb
+++ b/app/views/item_purchases/index.html.erb
@@ -10,7 +10,7 @@
       <%= image_tag "item-sample.png", class: 'buy-item-img' %>
       <div class='buy-item-right-content'>
         <h2 class='buy-item-text'>
-          <%= "商品説明" %>
+          <%= @items.info %>
         </h2>
         <div class='buy-item-price'>
           <p class='item-price-text'>¥<%= 999,999,999 %></p>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -21,7 +21,7 @@ app/assets/stylesheets/items/new.css %>
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%= f.file_field :image, id:"item-image" %>
+        <%= f.file_field @items.image, id:"item-image" %>
       </div>
     </div>
     <%# /出品画像 %>
@@ -31,13 +31,13 @@ app/assets/stylesheets/items/new.css %>
         商品名
         <span class="indispensable">必須</span>
       </div>
-      <%= f.text_area :product_name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <%= f.text_area @items.product_name, class:"items-text", id:"item-name", placeholder:@items.product_name, maxlength:"40" %>
       <div class="items-explain">
         <div class="weight-bold-text">
           商品の説明
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :info, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+        <%= f.text_area @items.info, class:"items-text", id:"item-info", placeholder:@items.info ,rows:"7" ,maxlength:"1000" %>
       </div>
     </div>
     <%# /商品名と商品説明 %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -27,12 +27,12 @@
 
     <%# ログインしていて、なおかつ、ログインしているユーザと出品しているユーザが同一人物でないとき表示しましょう。 %>
     <% if user_signed_in? && current_user.id == @items.user_id %>
-     <%= link_to '商品の編集', "items/edit", method: :get, class: "item-red-btn" %>
+     <%= link_to '商品の編集',edit_item_url , method: :get, class: "item-red-btn" %>
      <p class='or-text'>or</p>
      <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
     <% else %>
      <%# 商品が売れていない場合はこちらを表示しましょう %>
-     <%= link_to '購入画面に進む', "transactions/index" ,class:"item-red-btn"%>
+     <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
      <%# //商品が売れていない場合はこちらを表示しましょう %>
     <% end %>
     <%# //ログインしていて、なおかつ、ログインしているユーザと出品しているユーザが同一人物でないとき表示しましょう。 %>


### PR DESCRIPTION
商品情報編集機能の実装しましたのでご確認を宜しくお願い致します。
実装した機能は以下の通りです。

・商品情報（商品画像・商品名・商品の状態など）を変更できること
・出品者だけが編集ページに遷移できること
・商品出品時とほぼ同じUIで編集機能が実装できること
・商品名やカテゴリーの情報など、すでに登録されている商品情報は編集画面を開いた時点で表示されること
・エラーハンドリングができていること

ログインしたユーザーから見たトップページ
https://gyazo.com/f664b4420850a71cb181226b9407e482
ログインしたユーザーが出品した出品物の詳細表示画面
https://gyazo.com/66a2b822b8511e118131fa2c22057ae3
ログインしたユーザーが編集ページを開き情報が記録しているのを確認できる画像
https://gyazo.com/f05ae5db12ce8602f4d1232131090289