### PR TITLE
商品削除機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :move_to_index, except: [:index, :show, :edit, :new]
-  before_action :set_item, only: [:edit, :show]
+  before_action :set_item, only: [:edit, :show,:destroy]
 
   def index
     @items = Item.all.order(product_name: "DESC")
@@ -33,6 +33,16 @@ class ItemsController < ApplicationController
 
   def show
   end
+
+  def destroy
+    if 
+      @items.destroy
+      redirect_to root_path
+    else
+      render :show
+    end
+  end
+
 
   def move_to_index
     unless user_signed_in?

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -35,7 +35,7 @@ class ItemsController < ApplicationController
   end
 
   def destroy
-    if 
+    if current_user.id == @items.user_id
       @items.destroy
       redirect_to root_path
     else

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -29,7 +29,7 @@
     <% if user_signed_in? && current_user.id == @items.user_id %>
      <%= link_to '商品の編集',edit_item_url , method: :get, class: "item-red-btn" %>
      <p class='or-text'>or</p>
-     <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
+     <%= link_to '削除', item_path(@items), method: :delete, class:'item-destroy' %>
     <% else %>
      <%# 商品が売れていない場合はこちらを表示しましょう %>
      <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>


### PR DESCRIPTION
フリマアプリの商品削除機能を実装しましたので確認を御願いします。

実装条件は
出品者だけが商品情報を削除できることのみです。
商品を削除したらトップページへ戻るようにしています。
